### PR TITLE
adding benchmark to extractor

### DIFF
--- a/benchmark/kostya/simdjson_ondemand.h
+++ b/benchmark/kostya/simdjson_ondemand.h
@@ -24,6 +24,35 @@ struct simdjson_ondemand {
 
 BENCHMARK_TEMPLATE(kostya, simdjson_ondemand)->UseManualTime();
 
+
+#if SIMDJSON_SUPPORTS_EXTRACT
+using namespace simdjson::ondemand;
+
+struct simdjson_ondemand_extract {
+  static constexpr diff_flags DiffFlags = diff_flags::NONE;
+
+  ondemand::parser parser{};
+
+  bool run(simdjson::padded_string &json, std::vector<point> &result) {
+    auto doc = parser.iterate(json);
+    for (ondemand::object object_point : doc.find_field("coordinates")) {
+      point p;
+      auto error = object_point.extract(
+        to{"x", p.x},
+        to{"y", p.y},
+        to{"z", p.z}
+      );
+      if(error) { return false; }
+      result.push_back(p);
+    }
+    return true;
+  }
+};
+
+BENCHMARK_TEMPLATE(kostya, simdjson_ondemand_extract)->UseManualTime();
+
+#endif // SIMDJSON_SUPPORTS_EXTRACT
+
 } // namespace kostya
 
 #endif // SIMDJSON_EXCEPTIONS

--- a/benchmark/partial_tweets/simdjson_ondemand.h
+++ b/benchmark/partial_tweets/simdjson_ondemand.h
@@ -73,7 +73,7 @@ struct simdjson_ondemand_extract {
         }},
         to{"retweet_count", t.retweet_count},
         to{"favorite_count", t.favorite_count});
-        if(error) { throw simdjson_error(error); }
+        if(error) { return false; }
         result.push_back(t);
     }
     return true;

--- a/benchmark/partial_tweets/simdjson_ondemand.h
+++ b/benchmark/partial_tweets/simdjson_ondemand.h
@@ -9,7 +9,7 @@ namespace partial_tweets {
 using namespace simdjson;
 
 struct simdjson_ondemand {
-  using StringType=std::string_view;
+  using StringType = std::string_view;
 
   ondemand::parser parser{};
 
@@ -42,6 +42,48 @@ struct simdjson_ondemand {
 };
 
 BENCHMARK_TEMPLATE(partial_tweets, simdjson_ondemand)->UseManualTime();
+
+
+#if SIMDJSON_SUPPORTS_EXTRACT
+
+using namespace simdjson::ondemand;
+
+struct simdjson_ondemand_extract {
+  using StringType = std::string_view;
+  ondemand::parser parser{};
+  bool run(simdjson::padded_string &json, std::vector<tweet<std::string_view>> &result) {
+    // Walk the document, parsing the tweets as we go
+    auto doc = parser.iterate(json);
+    for (ondemand::object tweet_object : doc.find_field("statuses")) {
+      tweet<std::string_view> t;
+      auto error = tweet_object.extract(
+        to{"created_at", t.created_at},
+        to{"id", t.id},
+        to{"text", t.result},
+        to{"in_reply_to_status_id", [&t](auto val) {
+          if(val.is_null()) {
+            t.in_reply_to_status_id = 0;
+          } else {
+            t.in_reply_to_status_id = val;
+          }
+         }},
+        to{"user", sub{
+          to{"id", t.user.id},
+          to{"screen_name", t.user.screen_name},
+        }},
+        to{"retweet_count", t.retweet_count},
+        to{"favorite_count", t.favorite_count});
+        if(error) { throw simdjson_error(error); }
+        result.push_back(t);
+    }
+    return true;
+  }
+};
+
+BENCHMARK_TEMPLATE(partial_tweets, simdjson_ondemand_extract)->UseManualTime();
+
+
+#endif
 
 } // namespace partial_tweets
 


### PR DESCRIPTION
This is a PR on top of the extractor PR at https://github.com/simdjson/simdjson/pull/2247

```
cmake --build build20  --target bench_ondemand
```


Preliminary benchmark suggests a small performance loss... The difference is small, but I observe it in two different benchmarks.

Can you check what you get?

## partial_tweets

```
./build20/benchmark/bench_ondemand --benchmark_filter=partial_tweets
```

```
partial_tweets<simdjson_ondemand>/manual_time             147613 ns       160362 ns         4571 best_bytes_per_sec=4.35744G best_docs_per_sec=6.89998k best_items_per_sec=689.998k bytes=631.515k bytes_per_second=3.98438G/s docs_per_sec=6.77449k/s items=100 items_per_second=677.449k/s [BEST: throughput=  4.36 GB/s doc_throughput=  6899 docs/s items=       100 avg_time=    147612 ns]
partial_tweets<simdjson_ondemand_extract>/manual_time     160835 ns       173621 ns         4340 best_bytes_per_sec=4.14078G best_docs_per_sec=6.5569k best_items_per_sec=655.69k bytes=631.515k bytes_per_second=3.65681G/s docs_per_sec=6.21754k/s items=100 items_per_second=621.754k/s [BEST: throughput=  4.14 GB/s doc_throughput=  6556 docs/s items=       100 avg_time=    160835 ns]
```

## kostya

```
./build20/benchmark/bench_ondemand --benchmark_filter=kostya
```


```
kostya<simdjson_ondemand>/manual_time           42895521 ns     46789562 ns           16 best_bytes_per_sec=3.23009G best_docs_per_sec=23.525 best_items_per_sec=12.3339M bytes=137.305M bytes_per_second=2.98109G/s docs_per_sec=23.3125/s items=524.288k items_per_second=12.2224M/s [BEST: throughput=  3.23 GB/s doc_throughput=    23 docs/s items=    524288 avg_time=  42895520 ns]
kostya<simdjson_ondemand_extract>/manual_time   45543115 ns     49405825 ns           15 best_bytes_per_sec=3.0295G best_docs_per_sec=22.064 best_items_per_sec=11.5679M bytes=137.305M bytes_per_second=2.80778G/s docs_per_sec=21.9572/s items=524.288k items_per_second=11.5119M/s [BEST: throughput=  3.03 GB/s doc_throughput=    22 docs/s items=    524288 avg_time=  45543115 ns]
```