### PR TITLE
extractor PR with clangcl tweaks

### DIFF
--- a/.github/workflows/vs17-clang-ci.yml
+++ b/.github/workflows/vs17-clang-ci.yml
@@ -13,15 +13,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {gen: Visual Studio 17 2022, arch: x64, build_type: Debug}
-          - {gen: Visual Studio 17 2022, arch: x64, build_type: Release}
-          - {gen: Visual Studio 17 2022, arch: x64, build_type: RelWithDebInfo}
+          - {gen: Visual Studio 17 2022, arch: x64, build_type: Debug, cxx: 17}
+          - {gen: Visual Studio 17 2022, arch: x64, build_type: Debug, cxx: 20}
+          - {gen: Visual Studio 17 2022, arch: x64, build_type: Release, cxx: 17}
     steps:
     - name: checkout
       uses: actions/checkout@v4
     - name: Configure
       run: |
-        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}}  -T ClangCL -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -B build
+        cmake -G "${{matrix.gen}}" -A ${{matrix.arch}} -DSIMDJSON_CXX_STANDARD=${{matrix.cxx}} -T ClangCL -DSIMDJSON_DEVELOPER_MODE=ON -DSIMDJSON_COMPETITION=OFF -B build
     - name: Build
       run: cmake --build build --config ${{matrix.build_type}} --verbose
     - name: Run tests

--- a/include/simdjson/fallback/bitmanipulation.h
+++ b/include/simdjson/fallback/bitmanipulation.h
@@ -9,7 +9,7 @@ namespace simdjson {
 namespace fallback {
 namespace {
 
-#if defined(_MSC_VER) && !defined(_M_ARM64) && !defined(_M_X64)
+#if SIMDJSON_REGULAR_VISUAL_STUDIO && !defined(_M_ARM64) && !defined(_M_X64)
 static inline unsigned char _BitScanForward64(unsigned long* ret, uint64_t x) {
   unsigned long x0 = (unsigned long)x, top, bottom;
   _BitScanForward(&top, (unsigned long)(x >> 32));
@@ -28,7 +28,7 @@ static unsigned char _BitScanReverse64(unsigned long* ret, uint64_t x) {
 
 /* result might be undefined when input_num is zero */
 simdjson_inline int leading_zeroes(uint64_t input_num) {
-#ifdef _MSC_VER
+#ifdef SIMDJSON_REGULAR_VISUAL_STUDIO
   unsigned long leading_zero = 0;
   // Search the mask data from most significant bit (MSB)
   // to least significant bit (LSB) for a set bit (1).
@@ -38,7 +38,7 @@ simdjson_inline int leading_zeroes(uint64_t input_num) {
     return 64;
 #else
   return __builtin_clzll(input_num);
-#endif// _MSC_VER
+#endif// SIMDJSON_REGULAR_VISUAL_STUDIO
 }
 
 } // unnamed namespace

--- a/include/simdjson/generic/ondemand/object-inl.h
+++ b/include/simdjson/generic/ondemand/object-inl.h
@@ -19,7 +19,7 @@ namespace ondemand {
 #ifdef SIMDJSON_SUPPORTS_EXTRACT
 
 
-#ifdef _MSC_VER
+#if SIMDJSON_REGULAR_VISUAL_STUDIO
 template <endpoint ...Funcs>
 simdjson_inline error_code object::extract(Funcs&&... endpoints) {
   return iter.on_field_raw([&, eps = std::make_tuple(std::forward<Funcs>(endpoints)...)](auto field_key, error_code& error) mutable {

--- a/include/simdjson/generic/ondemand/object.h
+++ b/include/simdjson/generic/ondemand/object.h
@@ -86,7 +86,7 @@ public:
    */
   template <endpoint ...Funcs>
   simdjson_inline error_code extract(Funcs&&... endpoints)
-#ifndef _MSC_VER // msvc thinks noexcept is not the same in definition
+#ifndef SIMDJSON_REGULAR_VISUAL_STUDIO // msvc thinks noexcept is not the same in definition
  noexcept((nothrow_endpoint<Funcs> && ...))
 #endif
  ;


### PR DESCRIPTION
@the-moisrex Your PR use `_MSC_VER` to detect visual studio, but we already have a macro for that (`SIMDJSON_REGULAR_VISUAL_STUDIO`). The problem with `_MSC_VER`  is that it also gets defined when compiling with LLVM under Visual Studio.

If you merge this PR, it will affect your own PR (https://github.com/simdjson/simdjson/pull/2247).
